### PR TITLE
Include defaults in knitr engine

### DIFF
--- a/R/knit.R
+++ b/R/knit.R
@@ -6,6 +6,14 @@ knit_d3 <- function (options) {
     options$data <- get(options$data, envir = globalenv())
   }
   
+  if (is.null(options$version)) {
+    options$version <- "5"
+  }
+  
+  if (is.null(options$container)) {
+    options$container <- "svg"
+  }
+  
   if ("reactive" %in% class(options$data)) {
     widget <- renderD3({
       r2d3(


### PR DESCRIPTION
Fix for https://github.com/rstudio/r2d3/issues/5 introduced from removing `container` and `version` defaults from https://github.com/rstudio/r2d3/commit/6031d52636612506b6f58c1d6f1943c043b865ee.