### PR TITLE
Avoid using knitr figure when width and height are set

### DIFF
--- a/R/render.R
+++ b/R/render.R
@@ -29,7 +29,7 @@ r2d3 <- function(
   dependencies = NULL,
   width = NULL,
   height = NULL,
-  sizing = default_sizing(),
+  sizing = default_sizing(width, height),
   viewer = c("internal", "external", "browser")
   )
 {
@@ -86,13 +86,21 @@ r2d3 <- function(
 
 #' Default sizing policy for r2d3 widgets
 #' 
+#' @param width Desired width for output widget.
+#' @param height Desired height for output widget.
+#' 
 #' @details Use [htmlwidgets::sizingPolicy()] to specify an
 #'   alternate policy.
 #' 
 #' @keywords internal
 #' @export
-default_sizing <- function() {
-  htmlwidgets::sizingPolicy(browser.fill = TRUE)
+default_sizing <- function(width = NULL, height = NULL) {
+  htmlwidgets::sizingPolicy(
+    browser.fill = TRUE,
+    defaultWidth = if (is.null(width)) NULL else "auto",
+    defaultHeight = if (is.null(height)) NULL else "auto",
+    knitr.figure = if (!is.null(width) || !is.null(height)) FALSE else TRUE
+  )
 }
 
 


### PR DESCRIPTION
Currently, setting a height of 100 has no effect in notebooks...

<img width="1031" alt="screen shot 2018-04-12 at 5 21 29 pm" src="https://user-images.githubusercontent.com/3478847/38710654-552fc580-3e76-11e8-9697-5707743b7831.png">

Explicit height is supported in notebooks is by marking an htmlwidget as not a knitr figure, see https://github.com/rstudio/rstudio/pull/828

This change opts-out from being rendered a a knitr figure when width or height are set to get the correct sizing:

<img width="1029" alt="screen shot 2018-04-12 at 5 22 30 pm" src="https://user-images.githubusercontent.com/3478847/38710730-bb626272-3e76-11e8-83f9-9c124a238de3.png">

CC: @jjallaire @jmcphers