### PR TITLE
Add support for d3 extensions as dependencies

### DIFF
--- a/R/render.R
+++ b/R/render.R
@@ -94,7 +94,8 @@ r2d3 <- function(
     container = container,
     options = options,
     script = script_wrap(
-      script_read(c(inline_dependencies$js, script)),
+      inline_dependencies$js,
+      script,
       container
     ),
     style = script_read(inline_dependencies$css),

--- a/R/script.R
+++ b/R/script.R
@@ -1,12 +1,28 @@
 # Prepares a D3 script to be embedable into a widget
-script_wrap <- function(contents, container) {
+script_wrap <- function(deps, script, container) {
+  deps_contents <- script_read(deps)
+  script_contents <- script_read(script)
+  
+  script_contents <- paste(
+    # some libraries expect the container to be created from the extended d3 object.
+    container, " = d3.select(", container, ".node());",
+    "\n",
+    script_contents,
+    sep = ""
+  )
+  
   paste(
-    c(
-      paste("var d3Script = function(d3, r2d3, data, ", container, ", width, height, options, theme, console) {", sep = ""),
-      contents,
-      "};"
-    ),
-    collapse = "\n"
+    "var d3Script = function(d3, r2d3, data, ", container, ", width, height, options, theme, console) {",
+    "\n",
+    # some libraries expect d3 to be accessible as this.d3
+    "this.d3 = d3;",
+    "\n",
+    deps_contents,
+    "\n",
+    script_contents,
+    "\n",
+    "};",
+    sep = ""
   )
 }
 

--- a/tests/testthat/barchart/tests/shinytest-expected/001.json
+++ b/tests/testthat/barchart/tests/shinytest-expected/001.json
@@ -15,7 +15,7 @@
         "type": "integer",
         "container": "svg",
         "options": null,
-        "script": "var d3Script = function(d3, r2d3, data, svg, width, height, options, theme, console) {\n/* R2D3 Source File:  ../baranim.js */\n// !preview r2d3 data=c(0.3, 0.6, 0.8, 0.95, 0.40, 0.20)\n//\n// r2d3: https://rstudio.github.io/r2d3\n//\n\nvar bars = r2d3.svg.selectAll('rect')\n    .data(r2d3.data);\n    \nbars.enter()\n    .append('rect')\n      .attr('width', function(d) { return d * width; })\n      .attr('height', '20px')\n      .attr('y', function(d, i) { return i * 22; })\n      .attr('fill', 'steelblue');\n\nbars.exit().remove();\n\nbars.transition()\n  .duration(0)\n  .attr(\"width\", function(d) { return d * width; });\n};",
+        "script": "var d3Script = function(d3, r2d3, data, svg, width, height, options, theme, console) {\nthis.d3 = d3;\n\nsvg = d3.select(svg.node());\n/* R2D3 Source File:  ../baranim.js */\n// !preview r2d3 data=c(0.3, 0.6, 0.8, 0.95, 0.40, 0.20)\n//\n// r2d3: https://rstudio.github.io/r2d3\n//\n\nvar bars = r2d3.svg.selectAll('rect')\n    .data(r2d3.data);\n    \nbars.enter()\n    .append('rect')\n      .attr('width', function(d) { return d * width; })\n      .attr('height', '20px')\n      .attr('y', function(d, i) { return i * 22; })\n      .attr('fill', 'steelblue');\n\nbars.exit().remove();\n\nbars.transition()\n  .duration(0)\n  .attr(\"width\", function(d) { return d * width; });\n};",
         "style": null,
         "version": 5,
         "theme": {

--- a/tests/testthat/barchart/tests/shinytest-expected/002.json
+++ b/tests/testthat/barchart/tests/shinytest-expected/002.json
@@ -15,7 +15,7 @@
         "type": "numeric",
         "container": "svg",
         "options": null,
-        "script": "var d3Script = function(d3, r2d3, data, svg, width, height, options, theme, console) {\n/* R2D3 Source File:  ../baranim.js */\n// !preview r2d3 data=c(0.3, 0.6, 0.8, 0.95, 0.40, 0.20)\n//\n// r2d3: https://rstudio.github.io/r2d3\n//\n\nvar bars = r2d3.svg.selectAll('rect')\n    .data(r2d3.data);\n    \nbars.enter()\n    .append('rect')\n      .attr('width', function(d) { return d * width; })\n      .attr('height', '20px')\n      .attr('y', function(d, i) { return i * 22; })\n      .attr('fill', 'steelblue');\n\nbars.exit().remove();\n\nbars.transition()\n  .duration(0)\n  .attr(\"width\", function(d) { return d * width; });\n};",
+        "script": "var d3Script = function(d3, r2d3, data, svg, width, height, options, theme, console) {\nthis.d3 = d3;\n\nsvg = d3.select(svg.node());\n/* R2D3 Source File:  ../baranim.js */\n// !preview r2d3 data=c(0.3, 0.6, 0.8, 0.95, 0.40, 0.20)\n//\n// r2d3: https://rstudio.github.io/r2d3\n//\n\nvar bars = r2d3.svg.selectAll('rect')\n    .data(r2d3.data);\n    \nbars.enter()\n    .append('rect')\n      .attr('width', function(d) { return d * width; })\n      .attr('height', '20px')\n      .attr('y', function(d, i) { return i * 22; })\n      .attr('fill', 'steelblue');\n\nbars.exit().remove();\n\nbars.transition()\n  .duration(0)\n  .attr(\"width\", function(d) { return d * width; });\n};",
         "style": null,
         "version": 5,
         "theme": {


### PR DESCRIPTION
Subset of https://github.com/rstudio/r2d3/pull/17

```js
// !preview r2d3 data=c(0.3, 0.6, 0.8, 0.95, 0.40, 0.20), container = "svg", dependencies = "~/jetpack.js"
//
// r2d3: https://rstudio.github.io/r2d3
//

var { svg, margin, height, width } = d3.conventions({
  sel: svg,
  totalWidth: width,
  totalHeight: height,
  margin: { top: 60, bottom: 60 }
});

var barHeight = Math.ceil(height / data.length);

svg.selectAll('rect')
  .data(data)
  .enter().append('rect')
    .attr('width', function(d) { return d * width; })
    .attr('height', barHeight)
    .attr('y', function(d, i) { return i * barHeight; })
    .attr('fill', 'steelblue');

```