### PR TITLE
qualify css with r2d3 class

### DIFF
--- a/vignettes/gallery/bullets/bullets.css
+++ b/vignettes/gallery/bullets/bullets.css
@@ -1,13 +1,13 @@
 
-.bullet { font: 10px sans-serif; }
-.bullet .marker { stroke: #000; stroke-width: 2px; }
-.bullet .tick line { stroke: #666; stroke-width: .5px; }
-.bullet .range.s0 { fill: #eee; }
-.bullet .range.s1 { fill: #ddd; }
-.bullet .range.s2 { fill: #ccc; }
-.bullet .measure.s0 { fill: lightsteelblue; }
-.bullet .measure.s1 { fill: steelblue; }
-.bullet .title { font-size: 14px; font-weight: bold; }
-.bullet .subtitle { fill: #999; }
+.r2d3 .bullet { font: 10px sans-serif; }
+.r2d3 .bullet .marker { stroke: #000; stroke-width: 2px; }
+.r2d3 .bullet .tick line { stroke: #666; stroke-width: .5px; }
+.r2d3 .bullet .range.s0 { fill: #eee; }
+.r2d3 .bullet .range.s1 { fill: #ddd; }
+.r2d3 .bullet .range.s2 { fill: #ccc; }
+.r2d3 .bullet .measure.s0 { fill: lightsteelblue; }
+.r2d3 .bullet .measure.s1 { fill: steelblue; }
+.r2d3 .bullet .title { font-size: 14px; font-weight: bold; }
+.r2d3 .bullet .subtitle { fill: #999; }
 
-.bullets { line-height: 0; }
+.r2d3 .bullets { line-height: 0; }

--- a/vignettes/gallery/cartogram/cartogram.css
+++ b/vignettes/gallery/cartogram/cartogram.css
@@ -1,9 +1,9 @@
-.land {
+.r2d3 .land {
   fill: #fff;
   stroke: #ccc;
 }
 
-.state {
+.r2d3 .state {
   fill: #ccc;
   stroke: #666;
 }

--- a/vignettes/gallery/chord/chord.css
+++ b/vignettes/gallery/chord/chord.css
@@ -1,7 +1,7 @@
-.group-tick line {
+.r2d3 .group-tick line {
   stroke: #000;
 }
 
-.ribbons {
+.r2d3 .ribbons {
   fill-opacity: 0.67;
 }

--- a/vignettes/gallery/dendogram/dendogram.css
+++ b/vignettes/gallery/dendogram/dendogram.css
@@ -1,20 +1,20 @@
-.node circle {
+.r2d3 .node circle {
   fill: #999;
 }
 
-.node text {
+.r2d3 .node text {
   font-family: sans-serif;
 }
 
-.node--internal circle {
+.r2d3 .node--internal circle {
   fill: #555;
 }
 
-.node--internal text {
+.r2d3 .node--internal text {
   text-shadow: 0 1px 0 #fff, 0 -1px 0 #fff, 1px 0 0 #fff, -1px 0 0 #fff;
 }
 
-.link {
+.r2d3 .link {
   fill: none;
   stroke: #555;
   stroke-opacity: 0.4;

--- a/vignettes/gallery/forcegraph/forcegraph.css
+++ b/vignettes/gallery/forcegraph/forcegraph.css
@@ -1,9 +1,9 @@
-.links line {
+.r2d3 .links line {
   stroke: #999;
   stroke-opacity: 0.6;
 }
 
-.nodes circle {
+.r2d3 .nodes circle {
   stroke: #fff;
   stroke-width: 1.5px;
 }

--- a/vignettes/gallery/morley/morley.css
+++ b/vignettes/gallery/morley/morley.css
@@ -1,18 +1,18 @@
-.box {
+.r2d3 .box {
   font: 10px sans-serif;
 }
 
-.box line,
-.box rect,
-.box circle {
+.r2d3 .box line,
+.r2d3 .box rect,
+.r2d3 .box circle {
   stroke-width: 1.5px;
 }
 
-.box .center {
+.r2d3 .box .center {
   stroke-dasharray: 3,3;
 }
 
-.box .outlier {
+.r2d3 .box .outlier {
   fill: none;
   stroke: #ccc;
 }

--- a/vignettes/gallery/population/population.css
+++ b/vignettes/gallery/population/population.css
@@ -1,29 +1,29 @@
-svg {
+.r2d3 svg {
   font: sans-serif;
 }
 
-.y.axis path {
+.r2d3 s.y.axis path {
   display: none;
 }
 
-.y.axis line {
+.r2d3 s.y.axis line {
   stroke: #fff;
   stroke-opacity: .2;
   shape-rendering: crispEdges;
 }
 
-.y.axis .zero line {
+.r2d3 s.y.axis .zero line {
   stroke: #000;
   stroke-opacity: 1;
 }
 
-.title {
+.r2d3 s.title {
   font: Helvetica Neue;
   fill: #666;
 }
 
-.birthyear,
-.age {
+.r2d3 s.birthyear,
+.r2d3 s.age {
   text-anchor: middle;
 }
 

--- a/vignettes/gallery/radialtree/radialtree.css
+++ b/vignettes/gallery/radialtree/radialtree.css
@@ -1,20 +1,20 @@
-.node circle {
+.r2d3 .node circle {
   fill: #999;
 }
 
-.node text {
+.r2d3 .node text {
   font: 10px sans-serif;
 }
 
-.node--internal circle {
+.r2d3 .node--internal circle {
   fill: #555;
 }
 
-.node--internal text {
+.r2d3 .node--internal text {
   text-shadow: 0 1px 0 #fff, 0 -1px 0 #fff, 1px 0 0 #fff, -1px 0 0 #fff;
 }
 
-.link {
+.r2d3 .link {
   fill: none;
   stroke: #555;
   stroke-opacity: 0.4;

--- a/vignettes/gallery/stackedbars/stackedbars.css
+++ b/vignettes/gallery/stackedbars/stackedbars.css
@@ -1,3 +1,3 @@
-label {
+.r2d3 label {
   display: block;
 }

--- a/vignettes/gallery/sunburst/sunburst.css
+++ b/vignettes/gallery/sunburst/sunburst.css
@@ -1,3 +1,0 @@
-body {
-  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
-}

--- a/vignettes/gallery/treemap/treemap.css
+++ b/vignettes/gallery/treemap/treemap.css
@@ -1,3 +1,3 @@
-svg {
+.r2d3 svg {
   font: 10px sans-serif;
 }

--- a/vignettes/gallery/voronoi/voronoi.css
+++ b/vignettes/gallery/voronoi/voronoi.css
@@ -1,22 +1,22 @@
-.links {
+.r2d3 .links {
   stroke: #000;
   stroke-opacity: 0.2;
 }
 
-.polygons {
+.r2d3 .polygons {
   fill: none;
   stroke: #000;
 }
 
-.polygons :first-child {
+.r2d3 .polygons :first-child {
   fill: #f00;
 }
 
-.sites {
+.r2d3 .sites {
   fill: #000;
   stroke: #fff;
 }
 
-.sites :first-child {
+.r2d3 .sites :first-child {
   fill: #fff;
 }


### PR DESCRIPTION
@javierluraschi This is the beginnings of addressing issue #23 however after thinking about it further I don't think it's enough.

Here we basically qualify all CSS references with `.r2d3`, which ensures that they don't leak out beyond r2d3 visualizations. However, this doesn't prevent the CSS from various r2d3 scripts affecting eachother, which means that it in some cases it will be impossible to compose a page or app that has 2 different r2d3 visualizations.

Some ways to overcome this:

1) We really want something like a shadow DOM however SVG doesn't support this: https://stackoverflow.com/questions/40810372/augmenting-svg-tag-with-shadow-dom

2) We could use a scoped styles polyfill like this one: https://github.com/thomaspark/scoper (or do our own version of this). Note that scoped styles have been removed from the HTML spec (likely in favor of the shadow DOM) but some browsers still support them natively. If we go this route we should probably research various available solutions and see which one is best.

3) We could parse the CSS and then inject our own unique ID. This parsing could actually be done on the client in JS w/ something like this: https://github.com/tabatkins/parse-css. Note that it is possible for us to know/control the element ID by passing `elementID` to `createWidget` (we'd just have to our own random/unique element ID implementation).

This PR is a placeholder for this work (my guess is that if take one of the above approaches then we'll get rid of the `.r2d3` prefixing b/c it will no longer be necessary.

