### PR TITLE
Improve CSS scoping for older browsers

### DIFF
--- a/R/render.R
+++ b/R/render.R
@@ -26,6 +26,12 @@
 #'
 #' @import htmlwidgets
 #' @import tools
+#' 
+#' @details
+#' 
+#' In order to correctly scope CSS styles correctly when multiple widgets are rendered,
+#' the Shadow DOM and the wecomponents polyfill is used, this feature can be turned off
+#' by setting the \code{r2d3.shadow} option to \code{FALSE}.
 #'
 #' @examples
 #'
@@ -113,7 +119,8 @@ r2d3 <- function(
     theme = list(
       default = default_theme(),
       runtime = runtime_theme()
-    )
+    ),
+    useShadow = getOption("r2d3.shadow", TRUE)
   )
   
   # resolve viewer if it's explicitly specified

--- a/R/render.R
+++ b/R/render.R
@@ -29,9 +29,9 @@
 #' 
 #' @details
 #' 
-#' In order to correctly scope CSS styles correctly when multiple widgets are rendered,
-#' the Shadow DOM and the wecomponents polyfill is used, this feature can be turned off
-#' by setting the \code{r2d3.shadow} option to \code{FALSE}.
+#' In order to scope CSS styles when multiple widgets are rendered, the Shadow DOM and
+#' the wecomponents polyfill is used, this feature can be turned off by setting the 
+#' \code{r2d3.shadow} option to \code{FALSE}.
 #'
 #' @examples
 #'

--- a/inst/htmlwidgets/lib/r2d3/r2d3-render.js
+++ b/inst/htmlwidgets/lib/r2d3/r2d3-render.js
@@ -15,6 +15,7 @@ function R2D3(el, width, height) {
   self.captureErrors = null;
   self.theme = {};
   self.style = null;
+  self.useShadow = true;
   
   self.setX = function(newX) {
     x = newX;
@@ -29,6 +30,10 @@ function R2D3(el, width, height) {
     }
     
     self.options = x.options;
+    
+    if (!x.useShadow) {
+      self.useShadow = false;
+    }
   };
   
   self.setContainer = function(container) {
@@ -48,9 +53,14 @@ function R2D3(el, width, height) {
   
   self.createRoot = function() {
     if (self.shadow === null) {
-      self.shadow = el.attachShadow({
-        mode: "open"
-      });
+      if (self.useShadow && el.attachShadow) {
+        self.shadow = el.attachShadow({
+          mode: "open"
+        });
+      }
+      else {
+        self.shadow = el;
+      }
     }
     
     if (self.root !== null) {

--- a/inst/htmlwidgets/lib/webcomponents/webcomponents.js
+++ b/inst/htmlwidgets/lib/webcomponents/webcomponents.js
@@ -1,3 +1,5 @@
+// webcomponents.js requires Set api which is not available in all browsers
+if (typeof(Set) !== "undefined") {
 /**
 @license @nocompile
 Copyright (c) 2018 The Polymer Project Authors. All rights reserved.
@@ -231,3 +233,4 @@ return f},Map.prototype[sh.iterator]=function(){function a(a,f,k){for(;;)switch(
 function(){return this};return f},String.prototype[sh.iterator]=function(){function a(a,e,h){for(;;)switch(b){case 0:c=0;case 1:if(!(c<d.length)){b=3;break}b=4;return{value:d[c],done:!1};case 4:if(1!=a){b=5;break}b=-1;throw h;case 5:case 2:c++;b=1;break;case 3:b=-1;default:return{value:void 0,done:!0}}}var b=0,c,d=this,e={next:function(b){return a(0,b,void 0)},throw:function(b){return a(1,void 0,b)},return:function(){throw Error("Not yet implemented");}};ea();e[Symbol.iterator]=function(){return this};
 return e});var th=document.createElement("style");th.textContent="body {transition: opacity ease-in 0.2s; } \nbody[unresolved] {opacity: 0; display: block; overflow: hidden; position: relative; } \n";var uh=document.querySelector("head");uh.insertBefore(th,uh.firstChild);var vh=window.customElements,wh=!1,xh=null;vh.polyfillWrapFlushCallback&&vh.polyfillWrapFlushCallback(function(a){xh=a;wh&&a()});function yh(){window.HTMLTemplateElement.bootstrap&&window.HTMLTemplateElement.bootstrap(window.document);xh&&xh();wh=!0;window.WebComponents.ready=!0;document.dispatchEvent(new CustomEvent("WebComponentsReady",{bubbles:!0}))}
 "complete"!==document.readyState?(window.addEventListener("load",yh),window.addEventListener("DOMContentLoaded",function(){window.removeEventListener("load",yh);yh()})):yh();}).call(this);
+}

--- a/man/r2d3.Rd
+++ b/man/r2d3.Rd
@@ -46,6 +46,11 @@ browser.}
 \description{
 Visualize data using a custom D3 visualization script
 }
+\details{
+In order to scope CSS styles when multiple widgets are rendered, the Shadow DOM and
+the wecomponents polyfill is used, this feature can be turned off by setting the
+\code{r2d3.shadow} option to \code{FALSE}.
+}
 \examples{
 
 library(r2d3)

--- a/tests/testthat/barchart/tests/shinytest-expected/001.json
+++ b/tests/testthat/barchart/tests/shinytest-expected/001.json
@@ -24,7 +24,8 @@
             "foreground": "#000000"
           },
           "runtime": null
-        }
+        },
+        "useShadow": true
       },
       "evals": [
 

--- a/tests/testthat/barchart/tests/shinytest-expected/002.json
+++ b/tests/testthat/barchart/tests/shinytest-expected/002.json
@@ -24,7 +24,8 @@
             "foreground": "#000000"
           },
           "runtime": null
-        }
+        },
+        "useShadow": true
       },
       "evals": [
 


### PR DESCRIPTION
Follow up from https://github.com/rstudio/r2d3/pull/27, mostly to improve support in RStudio 1.1:

1. RStudio 1.1 was triggering errors in the console. This was due to `Set` not available in JavaScript.
2. RStudio 1.1 was not triggering resize for the widgets, this was due to we components.js not fully loading and is now fixed.

That said, this change does not enable the polyfill in RStudio 1.1, this is fine for the most part since RStudio uses iFrames in most cases (viewer, notebooks, etc) so the CSS is correctly scoped. However,  flexdashboard preview and other cases that host multiple widgets won't properly scope the CSS until the document is opened in the web browser.