### PR TITLE
rstudio pre-release: check for in .onLoad and reference in the docs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,7 @@ LazyData: TRUE
 Depends:
   R (>= 3.1.2)
 Imports:
-  htmlwidgets (>= 1.2), htmltools, jsonlite
+  htmlwidgets (>= 1.2), htmltools, jsonlite, rstudioapi
 Suggests:
   knitr,
   rmarkdown,

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,6 +1,57 @@
 .onLoad <- function(...) {
+  
   if (requireNamespace("knitr", quietly = TRUE)) {
     knit_engines <- get("knit_engines", envir = asNamespace("knitr"))
     knit_engines$set(d3 = knit_d3)
   }
+  
+  rstudio <- rstudio_version()
+  if (!is.null(rstudio)) {
+    
+    # check for desktop mode on windows and linux (other modes are fine)
+    if (!is_osx() && (rstudio$mode == "desktop")) {
+      
+      if (rstudio$version < "1.2.637")
+        packageStartupMessage(
+          "r2d3 should be run under RStudio v1.2 or higher. Please update at:\n",
+          "https://www.rstudio.com/rstudio/download/preview/\n"
+        )
+    }
+  }
 }
+
+# get the current rstudio version and mode (desktop vs. server)
+rstudio_version <- function() {
+  
+  # Running at the RStudio console
+  if (rstudioapi::isAvailable()) {
+    
+    rstudioapi::versionInfo()
+    
+    # Running in a child process
+  } else if (!is.na(Sys.getenv("RSTUDIO", unset = NA))) {
+    
+    # detect desktop vs. server using server-only environment variable
+    mode <- ifelse(is.na(Sys.getenv("RSTUDIO_HTTP_REFERER", unset = NA)),
+                   "desktop", "server")
+    
+    # detect version using Rmd new env var added in 1.2.638
+    version <- Sys.getenv("RSTUDIO_VERSION", unset = "1.1")
+    
+    # return version info
+    list(
+      mode = mode,
+      version = version
+    )
+    
+    # Not running in RStudio
+  } else {
+    NULL
+  }
+}
+
+is_osx <- function() {
+  Sys.info()["sysname"] == "Darwin"
+}
+
+

--- a/README.md
+++ b/README.md
@@ -56,17 +56,15 @@ First, install the package from GitHub as follows:
 devtools::install_github("rstudio/r2d3")
 ```
 
-Next, install the [daily build](https://dailies.rstudio.com) of RStudio
-(you need this version of RStudio to take advantage of various
-integrated tools for authoring D3 scripts with
-r2d3):
+Next, install the [preview release of RStudio
+v1.2](https://www.rstudio.com/rstudio/download/preview/) of RStudio (you
+need this version of RStudio to take advantage of various integrated
+tools for authoring D3 scripts with r2d3).
 
-<a href="https://dailies.rstudio.com"><img src="tools/README/daily_build.png" class="screenshot" width=600/></a>
-
-Once you’ve installed the package and the RStudio daily build you have
-the tools required to work with **r2d3**. Below, we’ll describe basic
-workflow within RStudio and techniques for including visualizations in R
-Markdown and Shiny applications.
+Once you’ve installed the package and the RStudio v1.2 preview release
+you have the tools required to work with **r2d3**. Below, we’ll describe
+basic workflow within RStudio and techniques for including
+visualizations in R Markdown and Shiny applications.
 
 ## About D3
 
@@ -140,15 +138,16 @@ are provided automatically are:
 1)  So that you can dynamically bind data from R to visualizations; and
 
 2)  So that **r2d3** can automatically handle dynamic resizing for your
-    visualization. Most D3 examples have a static size. This is fine for
+    visualization. Most D3 examples have a static size. This if fine for
     an example but not very robust for including the visualization
     within a report, dashboard, or application.
 
 ## D3 Preview
 
-The [daily build](https://dailies.rstudio.com) of RStudio includes
-support for previewing D3 scripts as you write them. To try this out,
-create a D3 script using the new file menu:
+The [RStudio v1.2 preview
+release](https://www.rstudio.com/rstudio/download/preview/) of RStudio
+includes support for previewing D3 scripts as you write them. To try
+this out, create a D3 script using the new file menu:
 
 <img src="tools/README/new_script.png" class="screenshot" width=600/>
 
@@ -241,6 +240,11 @@ shinyApp(ui = ui, server = server)
 
 <img src="tools/README/baranim-1.gif" class="illustration" width=600/>
 
+See the article on [Using r2d3 with
+Shiny](https://rstudio.github.io/r2d3/articles/shiny.html) to learn more
+(including how to create custom Shiny inputs that respond to user
+interaction with D3 visualizations).
+
 ## Learning More
 
 To learn the basics of D3 and see some examples that might inspire your
@@ -276,6 +280,12 @@ For next steps on learning on how to use **r2d3**, see these articles:
 
 Once you are familar with the basics, check out these articles on more
 advanced topics:
+
+[Using r2d3 with
+Shiny](https://rstudio.github.io/r2d3/articles/shiny.html) — Deriving
+insights from data is streamlined when users are able to modify a Shiny
+input, or click on a D3 visualization, and that action produces new
+results.
 
   - [CSS and JavaScript
     Dependencies](https://rstudio.github.io/r2d3/articles/dependencies.html)

--- a/vignettes/development_and_debugging.Rmd
+++ b/vignettes/development_and_debugging.Rmd
@@ -19,11 +19,11 @@ This article describes recommend workflow for developing D3 visualizations, incl
 
 2) Using browser debugging tools to pinpoint errors in your code.
 
-Note that the development tools described above are only fully supported within the [daily build](https://dailies.rstudio.com) of RStudio (as opposed to the current stable release) so you should download the daily build before trying these features out.
+Note that the development tools described above are only fully supported within the [RStudio v1.2 preview release](https://www.rstudio.com/rstudio/download/preview/) (as opposed to the current stable release) so you should download the daily build before trying these features out.
 
 ## RStudio Preview
 
-The [daily build](https://dailies.rstudio.com) of RStudio includes support for previewing D3 scripts as you write them. To try this out, create a D3 script using the new file menu:
+The [RStudio v1.2 preview release](https://www.rstudio.com/rstudio/download/preview/) includes support for previewing D3 scripts as you write them. To try this out, create a D3 script using the new file menu:
 
 <img src="images/new_script.png" class="screenshot" width=600/>
 

--- a/vignettes/introduction.Rmd
+++ b/vignettes/introduction.Rmd
@@ -51,11 +51,9 @@ First, install the package from GitHub as follows:
 devtools::install_github("rstudio/r2d3")
 ```
 
-Next, install the [daily build](https://dailies.rstudio.com) of RStudio (you need this version of RStudio to take advantage of various integrated tools for authoring D3 scripts with r2d3):
+Next, install the [preview release of RStudio v1.2](https://www.rstudio.com/rstudio/download/preview/) of RStudio (you need this version of RStudio to take advantage of various integrated tools for authoring D3 scripts with r2d3).
 
-<a href="https://dailies.rstudio.com"><img src="tools/README/daily_build.png" class="screenshot" width=600/></a>
-
-Once you've installed the package and the RStudio daily build you have the tools required to work with **r2d3**. Below, we'll describe basic workflow within RStudio and techniques for including visualizations in R Markdown and Shiny applications. 
+Once you've installed the package and the RStudio v1.2 preview release you have the tools required to work with **r2d3**. Below, we'll describe basic workflow within RStudio and techniques for including visualizations in R Markdown and Shiny applications. 
 
 ## About D3
 
@@ -113,7 +111,7 @@ On the other hand with **r2d3**, these variables are *provided automatically* so
 
 ## D3 Preview
 
-The [daily build](https://dailies.rstudio.com) of RStudio includes support for previewing D3 scripts as you write them. To try this out, create a D3 script using the new file menu:
+The [RStudio v1.2 preview release](https://www.rstudio.com/rstudio/download/preview/) of RStudio includes support for previewing D3 scripts as you write them. To try this out, create a D3 script using the new file menu:
 
 <img src="tools/README/new_script.png" class="screenshot" width=600/>
 

--- a/vignettes/visualization_options.Rmd
+++ b/vignettes/visualization_options.Rmd
@@ -175,5 +175,5 @@ The `viewer` argument to the `r2d3()` function enables you to customize how D3 v
 
 The "external" option is useful if your visualization requires more space than an RStudio pane affords. The "browser" option is useful if you need access to browser debugging tools during development.
 
-Note that the `viewer` options described above are only fully supported within the [daily build](https://dailies.rstudio.com) of RStudio (as opposed to the current stable release).
+Note that the `viewer` options described above are only fully supported within the [preview release of RStudio v1.2](https://www.rstudio.com/rstudio/download/preview/) (as opposed to the current stable release).
 


### PR DESCRIPTION
1) Check for (and recommend installation of when needed) the RStudio v1.2 preview release at startup

2) Update docs to refer to the preview release rather than the daily build