### PR TITLE
Fixed small syntax error in the onResize callback example code

### DIFF
--- a/vignettes/advanced_rendering.Rmd
+++ b/vignettes/advanced_rendering.Rmd
@@ -91,10 +91,10 @@ By default, when the element which contains your visualization is resized, **r2d
 You can provide an explicit resize handler by implementing the `r2d3.onResize()` callback. For example, in a force directed D3 layout you might do this in the `onResize()` callback:
 
 ```js
-r2d3.onResize(width, height) {
+r2d3.onResize(function(width, height) {
   force.force("center", d3.forceCenter(width / 2, height / 2))
     .restart();
-}
+});
 ```
 
 


### PR DESCRIPTION
Hi, 

Totally minor but I realized that there was a small syntax error in the `onResize` callback example in the advanced rendering section of the vignettes. Basically a few parts of the function call got omitted.  

It caused me some confusion for a while after I copied and pasted it in. Obviously if I had been paying closer attention I would have realized but hopefully this can save other oblivious users like me the few minutes of confusion. 

Let me know if I need to do anything in terms of rebuilding the pkgdown site in order to propagate this change through the repo. 