### PR TITLE
Fix refresh size (#59)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: r2d3
 Type: Package
 Title: Interface to 'D3' Visualizations
-Version: 0.2.3
+Version: 0.2.4
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
     person("JJ", "Allaire", role = c("aut")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# r2d3 0.2.4
+
+- Avoid width and height from changing when refreshing rendering (#59).
+
 # r2d3 0.2.3
 
 - Fix default theme when running under RStudio 1.2 (#50).

--- a/inst/htmlwidgets/lib/r2d3/r2d3-render.js
+++ b/inst/htmlwidgets/lib/r2d3/r2d3-render.js
@@ -6,8 +6,8 @@ function R2D3(el, width, height) {
   self.data = null;
   self.shadow = null;
   self.root = self.svg = self.canvas = null;
-  self.width = 0;
-  self.height = 0;
+  self.width = width;
+  self.height = height;
   self.options = null;
   self.resizer = null;
   self.renderer = null;
@@ -283,8 +283,6 @@ function R2D3(el, width, height) {
   
   self.widgetRender = function(x) {
     self.setX(x);
-    self.setWidth(width);
-    self.setHeight(height);
     
     if (!self.root) {
       self.setVersion(x.version);


### PR DESCRIPTION
Fix for https://github.com/rstudio/r2d3/issues/59.

I don't believe it was intentional to refresh the width and height during `onRender` since those values are come from the constructor and are only valid when the widget initializes.

Will rebuild the gallery and make sure all examples resize properly to validate this fix.